### PR TITLE
Refactor melee stats into single scriptable object

### DIFF
--- a/Assets/Scripts/AI/UnitAIController.cs
+++ b/Assets/Scripts/AI/UnitAIController.cs
@@ -1,0 +1,129 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Brain component that handles target acquisition and basic movement.
+/// Uses ScriptableObject stats for data-driven behavior.
+/// Communicates via events so other systems can react without tight coupling.
+/// </summary>
+[RequireComponent(typeof(FactionComponent))]
+public class UnitAIController : MonoBehaviour
+{
+    public enum AIState { Moving, Fighting }
+
+    // Single stats asset drives all AI behaviour
+    [SerializeField] private MeleeUnitStatsSO stats;
+    [SerializeField] private Transform longRangeDestination;
+
+    private FactionComponent _faction;
+    private AIState _state = AIState.Moving;
+    private GameObject _currentTarget;
+    private float _scanTimer;
+
+    public AIState State => _state;
+    public GameObject CurrentTarget => _currentTarget;
+
+    // Fired when a new target is acquired
+    public event Action<GameObject> OnTargetAcquired;
+
+    // Fired when the current target is lost
+    public event Action OnTargetLost;
+
+    private void Awake()
+    {
+        _faction = GetComponent<FactionComponent>();
+        if (stats == null)
+        {
+            Debug.LogError("[UnitAIController] Settings asset not assigned.", this);
+            enabled = false;
+        }
+    }
+
+    private void Update()
+    {
+        if (stats == null) return;
+
+        _scanTimer += Time.deltaTime;
+        if (_scanTimer >= stats.scanInterval)
+        {
+            _scanTimer = 0f;
+            ScanForTargets();
+        }
+
+        if (_state == AIState.Moving)
+        {
+            MoveTowards(longRangeDestination ? longRangeDestination.position : transform.position + transform.forward);
+        }
+        else if (_state == AIState.Fighting && _currentTarget != null)
+        {
+            MoveTowards(_currentTarget.transform.position);
+
+            float distance = Vector3.Distance(transform.position, _currentTarget.transform.position);
+            if (distance > stats.aggroRadius)
+            {
+                ClearTarget();
+            }
+        }
+    }
+
+    private void MoveTowards(Vector3 destination)
+    {
+        Vector3 dir = (destination - transform.position).normalized;
+        transform.position += dir * stats.moveSpeed * Time.deltaTime;
+        if (dir != Vector3.zero)
+        {
+            Quaternion targetRot = Quaternion.LookRotation(dir);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRot, Time.deltaTime * 10f);
+        }
+    }
+
+    private void ScanForTargets()
+    {
+        Collider[] hits = Physics.OverlapSphere(transform.position, stats.aggroRadius);
+        float closestDist = float.MaxValue;
+        GameObject closest = null;
+
+        foreach (var hit in hits)
+        {
+            if (hit.gameObject == gameObject) continue;
+
+            FactionComponent otherFaction = hit.GetComponent<FactionComponent>();
+            if (otherFaction == null) continue;
+            if (otherFaction.unitTeam == _faction.unitTeam) continue; // ignore allies
+
+            float dist = Vector3.Distance(transform.position, hit.transform.position);
+            if (dist < closestDist)
+            {
+                closestDist = dist;
+                closest = hit.gameObject;
+            }
+        }
+
+        if (closest != null)
+        {
+            SetTarget(closest);
+        }
+        else if (_state == AIState.Fighting)
+        {
+            ClearTarget();
+        }
+    }
+
+    private void SetTarget(GameObject target)
+    {
+        if (_currentTarget == target) return;
+
+        _currentTarget = target;
+        _state = AIState.Fighting;
+        OnTargetAcquired?.Invoke(target);
+    }
+
+    private void ClearTarget()
+    {
+        if (_state == AIState.Moving) return;
+
+        _currentTarget = null;
+        _state = AIState.Moving;
+        OnTargetLost?.Invoke();
+    }
+}

--- a/Assets/Scripts/Combat/FactionComponent.cs
+++ b/Assets/Scripts/Combat/FactionComponent.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+/// <summary>
+/// Identifies which team a GameObject belongs to.
+/// Other components read this to determine friend or foe.
+/// </summary>
+public class FactionComponent : MonoBehaviour
+{
+    public enum Team { Player, Enemy }
+
+    [Tooltip("Team allegiance of this unit")]
+    public Team unitTeam = Team.Player;
+}

--- a/Assets/Scripts/Combat/MeleeAttacker.cs
+++ b/Assets/Scripts/Combat/MeleeAttacker.cs
@@ -1,0 +1,85 @@
+using UnityEngine;
+using System;
+
+/// <summary>
+/// Handles melee attack logic by listening to UnitAIController events.
+/// Uses a DamageEffect to apply damage when in range and off cooldown.
+/// </summary>
+[RequireComponent(typeof(UnitAIController))]
+public class MeleeAttacker : MonoBehaviour
+{
+    // Shared stats asset provides attack rate and range
+    [SerializeField] private MeleeUnitStatsSO stats;
+    [SerializeField] private MonoBehaviour effectSource;
+
+    private IEffect _effect;
+    private UnitAIController _ai;
+    private GameObject _currentTarget;
+    private float _cooldownTimer;
+
+    private void Awake()
+    {
+        _ai = GetComponent<UnitAIController>();
+        _effect = effectSource as IEffect;
+        if (stats == null)
+        {
+            Debug.LogError("[MeleeAttacker] Stats asset not assigned.", this);
+            enabled = false;
+        }
+        if (_effect == null)
+        {
+            Debug.LogError("[MeleeAttacker] Effect source must implement IEffect.", this);
+            enabled = false;
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (_ai != null)
+        {
+            _ai.OnTargetAcquired += HandleTargetAcquired;
+            _ai.OnTargetLost += HandleTargetLost;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (_ai != null)
+        {
+            _ai.OnTargetAcquired -= HandleTargetAcquired;
+            _ai.OnTargetLost -= HandleTargetLost;
+        }
+    }
+
+    private void Update()
+    {
+        _cooldownTimer -= Time.deltaTime;
+
+        if (_currentTarget == null) return;
+
+        float distance = Vector3.Distance(transform.position, _currentTarget.transform.position);
+        if (distance <= stats.attackRange && _cooldownTimer <= 0f)
+        {
+            PerformAttack();
+            _cooldownTimer = stats.attackRate;
+        }
+    }
+
+    private void HandleTargetAcquired(GameObject target)
+    {
+        _currentTarget = target;
+    }
+
+    private void HandleTargetLost()
+    {
+        _currentTarget = null;
+    }
+
+    private void PerformAttack()
+    {
+        if (_effect != null && _currentTarget != null)
+        {
+            _effect.Apply(_currentTarget);
+        }
+    }
+}

--- a/Assets/Scripts/Data/MeleeUnitStatsSO.cs
+++ b/Assets/Scripts/Data/MeleeUnitStatsSO.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+/// <summary>
+/// Extended stats for melee units. Inherits base UnitStats and adds
+/// configuration for melee combat and AI behaviour so a single asset
+/// can drive all components of a melee unit.
+/// </summary>
+[CreateAssetMenu(fileName = "MeleeUnitStats", menuName = "TheFist/Melee Unit Stats")]
+public class MeleeUnitStatsSO : UnitStatsSO
+{
+    [Header("Melee Combat")]
+    [Tooltip("Seconds between consecutive melee attacks")]
+    public float attackRate = 1.5f;
+
+    [Tooltip("Distance within which melee attacks can hit")] 
+    public float attackRange = 1.5f;
+
+    [Header("AI Targeting")]
+    [Tooltip("Radius within which enemies will be detected")]
+    public float aggroRadius = 5f;
+
+    [Tooltip("Seconds between target scan cycles")]
+    public float scanInterval = 0.5f;
+
+    [Header("Movement")]
+    [Tooltip("Movement speed for AI controlled units")]
+    public float moveSpeed = 3f;
+}


### PR DESCRIPTION
## Summary
- replace separate AI and attack config assets with `MeleeUnitStatsSO`
- update `UnitAIController` and `MeleeAttacker` to use the shared stats asset
- remove redundant `MeleeAttackSettingsSO` and `UnitAISettingsSO`

## Testing
- `dmcs Assets/Scripts/AI/UnitAIController.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686667f314548323b2447ba1ed46fc61