### PR TITLE
Implement health system

### DIFF
--- a/Assets/Scripts/Combat/Health.cs
+++ b/Assets/Scripts/Combat/Health.cs
@@ -1,0 +1,143 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Manages the health of an entity and handles damage and healing logic.
+/// </summary>
+public class Health : MonoBehaviour, IDestructible, IHealable
+{
+    [Header("Stats")]
+    [Tooltip("Configuration asset containing health values.")]
+    public HealthStatsSO stats;
+
+    /// <summary>
+    /// Current amount of health.
+    /// </summary>
+    public float CurrentHealth { get; private set; }
+
+    /// <summary>
+    /// Indicates whether the entity has died.
+    /// </summary>
+    public bool IsDead { get; private set; }
+
+    /// <summary>
+    /// Fired whenever the health value changes. Parameters are current health and maximum health.
+    /// </summary>
+    public event Action<float, float> OnHealthChanged;
+
+    /// <summary>
+    /// Fired when the entity dies.
+    /// </summary>
+    public event Action<GameObject> OnDied;
+
+    private void Awake()
+    {
+        if (stats == null)
+        {
+            TryAutoAssignStats();
+        }
+
+        if (stats == null)
+        {
+            Debug.LogError($"[Health] HealthStatsSO is not assigned on {gameObject.name} and could not be auto-resolved.", this);
+            enabled = false;
+            return;
+        }
+
+        CurrentHealth = stats.maxHealth;
+        IsDead = false;
+    }
+
+    /// <summary>
+    /// Attempts to automatically assign the <see cref="stats"/> field by looking for an Entity component.
+    /// </summary>
+    private void TryAutoAssignStats()
+    {
+        // Entity component does not exist yet. Use reflection to fetch a field or property named "healthStats" if present.
+        Component entityComponent = GetComponent("Entity");
+        if (entityComponent == null)
+        {
+            return;
+        }
+
+        var entityType = entityComponent.GetType();
+        var statsField = entityType.GetField("healthStats");
+        if (statsField != null && statsField.GetValue(entityComponent) is HealthStatsSO soField)
+        {
+            stats = soField;
+            return;
+        }
+
+        var statsProperty = entityType.GetProperty("healthStats") ?? entityType.GetProperty("HealthStats");
+        if (statsProperty != null && statsProperty.GetValue(entityComponent) is HealthStatsSO soProperty)
+        {
+            stats = soProperty;
+        }
+    }
+
+    /// <summary>
+    /// Applies damage to this entity.
+    /// </summary>
+    /// <param name="baseDamage">Raw damage before mitigation.</param>
+    /// <param name="attacker">GameObject that initiated the attack.</param>
+    /// <param name="attackData">Definition of the attack that dealt the damage.</param>
+    public void TakeDamage(float baseDamage, GameObject attacker, AttackDefinitionSO attackData)
+    {
+        if (IsDead || stats == null)
+        {
+            return;
+        }
+
+        float finalDamage = Mathf.Max(baseDamage - stats.armor, 0f);
+        CurrentHealth = Mathf.Clamp(CurrentHealth - finalDamage, 0f, stats.maxHealth);
+
+        Debug.Log($"[Health] {gameObject.name} took {finalDamage} damage from {(attacker != null ? attacker.name : "Unknown")}. Remaining health: {CurrentHealth}/{stats.maxHealth}");
+
+        OnHealthChanged?.Invoke(CurrentHealth, stats.maxHealth);
+
+        DamageInfo damageInfo = new DamageInfo(attacker, gameObject, finalDamage, attackData);
+        GameEvents.TriggerOnUnitDamaged(damageInfo);
+
+        if (CurrentHealth <= 0f)
+        {
+            Die();
+        }
+    }
+
+    /// <summary>
+    /// Restores health to this entity.
+    /// </summary>
+    /// <param name="healAmount">Amount of health to restore.</param>
+    public void Heal(float healAmount)
+    {
+        if (IsDead || stats == null)
+        {
+            return;
+        }
+
+        float previousHealth = CurrentHealth;
+        CurrentHealth = Mathf.Clamp(CurrentHealth + healAmount, 0f, stats.maxHealth);
+
+        if (Math.Abs(CurrentHealth - previousHealth) > Mathf.Epsilon)
+        {
+            Debug.Log($"[Health] {gameObject.name} healed for {healAmount}. Current health: {CurrentHealth}/{stats.maxHealth}");
+            OnHealthChanged?.Invoke(CurrentHealth, stats.maxHealth);
+        }
+    }
+
+    /// <summary>
+    /// Handles the death of the entity.
+    /// </summary>
+    private void Die()
+    {
+        if (IsDead)
+        {
+            return;
+        }
+
+        IsDead = true;
+        Debug.Log($"[Health] {gameObject.name} died.");
+        OnDied?.Invoke(gameObject);
+        GameEvents.TriggerOnUnitDied(gameObject);
+    }
+}

--- a/Assets/Scripts/Core/Interfaces/IDestructible.cs
+++ b/Assets/Scripts/Core/Interfaces/IDestructible.cs
@@ -6,7 +6,8 @@ public interface IDestructible
     /// <summary>
     /// Applies damage to the object from a specified attacker.
     /// </summary>
-    /// <param name="amount">The damage amount.</param>
-    /// <param name="attacker">The attacking entity.</param>
-    void TakeDamage(float amount, Attacker attacker);
+    /// <param name="baseDamage">The raw damage amount before mitigation.</param>
+    /// <param name="attacker">The GameObject that initiated the attack.</param>
+    /// <param name="attackData">Data describing the type of attack used.</param>
+    void TakeDamage(float baseDamage, GameObject attacker, AttackDefinitionSO attackData);
 }

--- a/Assets/Scripts/Core/Structs/DamageInfo.cs
+++ b/Assets/Scripts/Core/Structs/DamageInfo.cs
@@ -2,10 +2,43 @@ using System;
 using UnityEngine;
 
 /// <summary>
-/// Data describing damage dealt to a unit.
-/// Currently empty; will be expanded with additional details in future iterations.
+/// Contains detailed information about a damage event.
 /// </summary>
 [Serializable]
 public struct DamageInfo
 {
+    /// <summary>
+    /// GameObject that caused the damage.
+    /// </summary>
+    public GameObject attacker;
+
+    /// <summary>
+    /// GameObject that received the damage.
+    /// </summary>
+    public GameObject victim;
+
+    /// <summary>
+    /// Final amount of damage dealt.
+    /// </summary>
+    public float damageAmount;
+
+    /// <summary>
+    /// Scriptable object describing the attack, if available.
+    /// </summary>
+    public AttackDefinitionSO attackData;
+
+    /// <summary>
+    /// Creates a new instance of DamageInfo.
+    /// </summary>
+    /// <param name="attacker">The GameObject that inflicted the damage.</param>
+    /// <param name="victim">The GameObject that received the damage.</param>
+    /// <param name="damageAmount">The final amount of damage dealt.</param>
+    /// <param name="attackData">Optional attack data associated with the damage.</param>
+    public DamageInfo(GameObject attacker, GameObject victim, float damageAmount, AttackDefinitionSO attackData)
+    {
+        this.attacker = attacker;
+        this.victim = victim;
+        this.damageAmount = damageAmount;
+        this.attackData = attackData;
+    }
 }


### PR DESCRIPTION
## Summary
- add `Health` component with damage and healing logic
- expand `DamageInfo` structure to include attacker, victim, damage and attack data
- update `IDestructible` interface to accept attacker GameObject
- allow `Health.TakeDamage` to forward attack info to `DamageInfo`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f9b3b1d908323a86c3a456d5ba2b9