### PR TITLE
Refine TargetScanner component

### DIFF
--- a/Assets/Scripts/Targeting/TargetScanner.cs
+++ b/Assets/Scripts/Targeting/TargetScanner.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Scans the surrounding area for objects implementing <see cref="IInteractable"/>
+/// according to parameters defined in a <see cref="TargetScannerSO"/> profile.
+/// Acts as the "eyes" of NPCs and automated players.
+/// </summary>
+public class TargetScanner : MonoBehaviour
+{
+    [Header("Configuration")]
+    [Tooltip("Profile defining scan radius and update frequency.")]
+    public TargetScannerSO scannerProfile;
+
+    /// <summary>
+    /// List of interactable targets currently detected within range.
+    /// </summary>
+    private readonly List<IInteractable> targetsInRange = new List<IInteractable>();
+
+    private float nextScanTime;
+
+    private void Awake()
+    {
+        if (scannerProfile == null)
+        {
+            Debug.LogError($"[TargetScanner] Scanner profile is not assigned on {gameObject.name}", this);
+            enabled = false;
+        }
+    }
+
+    private void Update()
+    {
+        if (scannerProfile == null) { return; }
+
+        if (Time.time >= nextScanTime)
+        {
+            ScanForTargets();
+            nextScanTime = Time.time + scannerProfile.scanFrequency;
+        }
+    }
+
+    /// <summary>
+    /// Performs a physics overlap to find all interactables within range.
+    /// </summary>
+    private void ScanForTargets()
+    {
+        targetsInRange.Clear();
+
+        Collider[] hits = Physics.OverlapSphere(transform.position, scannerProfile.detectionRadius);
+        foreach (Collider hit in hits)
+        {
+            if (hit.gameObject == gameObject) { continue; }
+
+            var interactable = hit.GetComponent(typeof(IInteractable)) as IInteractable;
+            if (interactable == null) { continue; }
+
+            targetsInRange.Add(interactable);
+        }
+
+        Debug.Log($"[TargetScanner] {targetsInRange.Count} targets detected by {gameObject.name}");
+    }
+
+
+    /// <summary>
+    /// Returns all currently detected interactable targets.
+    /// </summary>
+    /// <returns>List of targets in range.</returns>
+    public List<IInteractable> GetTargetsInRange()
+    {
+        return new List<IInteractable>(targetsInRange);
+    }
+
+    /// <summary>
+    /// Returns the closest interactable target regardless of type.
+    /// </summary>
+    /// <returns>The nearest target or null if none exist.</returns>
+    public IInteractable GetNearestTarget()
+    {
+        float closestSqr = float.PositiveInfinity;
+        IInteractable closest = null;
+        foreach (var target in targetsInRange)
+        {
+            if (target == null) { continue; }
+            Component c = target as Component;
+            if (c == null) { continue; }
+            float sqr = (c.transform.position - transform.position).sqrMagnitude;
+            if (sqr < closestSqr)
+            {
+                closestSqr = sqr;
+                closest = target;
+            }
+        }
+        return closest;
+    }
+
+    /// <summary>
+    /// Returns the nearest target of a specific interactable type.
+    /// </summary>
+    /// <typeparam name="T">Interface type derived from <see cref="IInteractable"/>.</typeparam>
+    /// <returns>The nearest target implementing T, or null if none found.</returns>
+    public T GetNearestTarget<T>() where T : class, IInteractable
+    {
+        float closestSqr = float.PositiveInfinity;
+        T closest = null;
+        foreach (var target in targetsInRange)
+        {
+            if (target is T typedTarget)
+            {
+                Component c = typedTarget as Component;
+                if (c == null) { continue; }
+                float sqr = (c.transform.position - transform.position).sqrMagnitude;
+                if (sqr < closestSqr)
+                {
+                    closestSqr = sqr;
+                    closest = typedTarget;
+                }
+            }
+        }
+        return closest;
+    }
+}

--- a/Assets/Scripts/Targeting/TargetScannerSO.cs
+++ b/Assets/Scripts/Targeting/TargetScannerSO.cs
@@ -1,9 +1,8 @@
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
-/// Holds configuration data for a TargetScanner component. This ScriptableObject
-/// allows designers to tweak scanning behaviour and interaction priorities without modifying code.
+/// Holds configuration data for a <see cref="TargetScanner"/> component. This
+/// ScriptableObject allows designers to tweak scanning behaviour without modifying code.
 /// </summary>
 [CreateAssetMenu(fileName = "TargetScanner", menuName = "TheFist/Target Scanner")]
 public class TargetScannerSO : ScriptableObject
@@ -22,20 +21,6 @@ public class TargetScannerSO : ScriptableObject
     [Tooltip("How often, in seconds, the scanner checks for targets.")]
     public float scanFrequency = 0.5f;
 
-    /// <summary>
-    /// Which interaction types this scanner is allowed to consider when looking for targets.
-    /// Multiple types can be combined because <see cref="InteractionType"/> is a flag enum.
-    /// </summary>
-    [Tooltip("Which interaction types this scanner is allowed to consider when looking for targets.")]
-    public InteractionType allowedInteractions = InteractionType.None;
 
-    [Header("Interaction Prioritization")]
-
-    /// <summary>
-    /// Defines how different interaction types are prioritised when multiple targets are detected.
-    /// Entries at the beginning of the list have higher priority.
-    /// </summary>
-    [Tooltip("Priority order of interaction types from highest to lowest priority.")]
-    public List<InteractionType> interactionPriority = new List<InteractionType>();
 }
 


### PR DESCRIPTION
## Summary
- simplify TargetScanner to only detect IInteractables
- remove DetermineInteractionType and interaction filters
- slim down TargetScannerSO

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686fada470d883238ddad7c973520361