### PR TITLE
Add projectile speed to attack data

### DIFF
--- a/Assets/Scripts/Combat/SimpleProjectile.cs
+++ b/Assets/Scripts/Combat/SimpleProjectile.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+
+/// <summary>
+/// Basic projectile that travels toward a target and applies damage on impact.
+/// </summary>
+public class SimpleProjectile : MonoBehaviour
+{
+    private float speed;
+
+    private GameObject target;
+    private GameObject attacker;
+    private AttackDefinitionSO attackData;
+
+    /// <summary>
+    /// Initializes the projectile with its attacker, target and attack data.
+    /// </summary>
+    /// <param name="attacker">Origin of the projectile.</param>
+    /// <param name="target">Target to hit.</param>
+    /// <param name="attackData">Attack definition used for damage calculation.</param>
+    public void Initialize(GameObject attacker, GameObject target, AttackDefinitionSO attackData)
+    {
+        if (target == null || attackData == null)
+        {
+            Debug.LogError("[SimpleProjectile] Invalid initialization parameters.", this);
+            Destroy(gameObject);
+            return;
+        }
+
+        this.attacker = attacker;
+        this.target = target;
+        this.attackData = attackData;
+        speed = attackData.projectileSpeed;
+    }
+
+    private void Update()
+    {
+        if (target == null)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Vector3 direction = (target.transform.position - transform.position).normalized;
+        transform.position += direction * speed * Time.deltaTime;
+
+        if (Vector3.Distance(transform.position, target.transform.position) <= 0.2f)
+        {
+            if (target.TryGetComponent<Health>(out var health))
+            {
+                health.TakeDamage(attackData.damage, attacker, attackData);
+            }
+            else
+            {
+                Debug.LogWarning("[SimpleProjectile] Target has no Health component.", this);
+            }
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Data/AttackDefinitionSO.cs
+++ b/Assets/Scripts/Data/AttackDefinitionSO.cs
@@ -47,4 +47,11 @@ public class AttackDefinitionSO : ScriptableObject
     /// </summary>
     [Tooltip("Prefab spawned when executing a ranged attack. Null for melee attacks.")]
     public GameObject projectilePrefab;
+
+    /// <summary>
+    /// Movement speed for projectiles spawned by this attack.
+    /// Only used when <see cref="projectilePrefab"/> is assigned.
+    /// </summary>
+    [Tooltip("Movement speed of projectiles spawned by this attack.")]
+    public float projectileSpeed = 10f;
 }


### PR DESCRIPTION
## Summary
- store projectile speed in `AttackDefinitionSO`
- remove public speed field from `SimpleProjectile`
- initialize projectile speed from the attack definition

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686faf8af1b08323b9f3b3b3368ae3af