### PR TITLE
Add basic game management system

### DIFF
--- a/Assets/Scripts/Core/Enums/GameState.cs
+++ b/Assets/Scripts/Core/Enums/GameState.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents the high level state of the game.
+/// </summary>
+public enum GameState
+{
+    /// <summary>
+    /// The game is at the main menu.
+    /// </summary>
+    MainMenu,
+
+    /// <summary>
+    /// Gameplay is active.
+    /// </summary>
+    Gameplay,
+
+    /// <summary>
+    /// Gameplay is paused.
+    /// </summary>
+    Paused,
+
+    /// <summary>
+    /// The player achieved victory.
+    /// </summary>
+    Victory,
+
+    /// <summary>
+    /// The player was defeated.
+    /// </summary>
+    Defeat
+}

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Central coordinator for high level game flow such as loading levels and
+/// tracking the current <see cref="GameState"/>.
+/// </summary>
+public class GameManager : MonoBehaviour
+{
+    /// <summary>
+    /// Global singleton instance.
+    /// </summary>
+    public static GameManager Instance { get; private set; }
+
+    /// <summary>
+    /// Current game state.
+    /// </summary>
+    public GameState CurrentState { get; private set; } = GameState.MainMenu;
+
+    [Header("Levels")]
+    [Tooltip("Collection of levels available in the game.")]
+    public List<LevelDataSO> levels = new List<LevelDataSO>();
+
+    /// <summary>
+    /// Currently loaded level index.
+    /// </summary>
+    private int currentLevelIndex = -1;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    private void OnEnable()
+    {
+        SubscribeToGameEvents();
+    }
+
+    private void OnDisable()
+    {
+        UnsubscribeFromGameEvents();
+    }
+
+    /// <summary>
+    /// Subscribes to global events used by the game manager.
+    /// </summary>
+    private void SubscribeToGameEvents()
+    {
+        GameEvents.OnVictory += HandleVictory;
+        GameEvents.OnDefeat += HandleDefeat;
+    }
+
+    /// <summary>
+    /// Unsubscribes from global events when the game manager is disabled.
+    /// </summary>
+    private void UnsubscribeFromGameEvents()
+    {
+        GameEvents.OnVictory -= HandleVictory;
+        GameEvents.OnDefeat -= HandleDefeat;
+    }
+
+    /// <summary>
+    /// Loads a level by index and initializes gameplay.
+    /// </summary>
+    /// <param name="levelIndex">Index of the level to load.</param>
+    public void LoadLevel(int levelIndex)
+    {
+        if (levelIndex < 0 || levelIndex >= levels.Count)
+        {
+            Debug.LogError($"[GameManager] Invalid level index {levelIndex}.", this);
+            return;
+        }
+
+        LevelDataSO levelData = levels[levelIndex];
+        if (levelData == null)
+        {
+            Debug.LogError($"[GameManager] Level data at index {levelIndex} is null.", this);
+            return;
+        }
+
+        currentLevelIndex = levelIndex;
+        CurrentState = GameState.Gameplay;
+        Debug.Log($"[GameManager] Loading level {levelData.levelName} ({levelIndex}).");
+
+        SceneManager.LoadScene(levelData.levelName);
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    /// <summary>
+    /// Called after a scene has loaded to initialize the level.
+    /// </summary>
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+
+        LevelDataSO levelData = null;
+        if (currentLevelIndex >= 0 && currentLevelIndex < levels.Count)
+        {
+            levelData = levels[currentLevelIndex];
+        }
+
+        LevelManager levelManager = FindObjectOfType<LevelManager>();
+        if (levelManager != null)
+        {
+            levelManager.InitializeLevel(levelData);
+        }
+        else
+        {
+            Debug.LogError("[GameManager] No LevelManager found in loaded scene.", this);
+        }
+    }
+
+    /// <summary>
+    /// Handles logic when the game ends in victory.
+    /// </summary>
+    private void HandleVictory()
+    {
+        CurrentState = GameState.Victory;
+        Debug.Log("[GameManager] Victory state reached.");
+    }
+
+    /// <summary>
+    /// Handles logic when the game ends in defeat.
+    /// </summary>
+    private void HandleDefeat()
+    {
+        CurrentState = GameState.Defeat;
+        Debug.Log("[GameManager] Defeat state reached.");
+    }
+}

--- a/Assets/Scripts/Core/LevelManager.cs
+++ b/Assets/Scripts/Core/LevelManager.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+/// <summary>
+/// Controls runtime behaviour for an individual level such as spawning
+/// gameplay elements and checking win conditions.
+/// </summary>
+public class LevelManager : MonoBehaviour
+{
+    [Header("Configuration")]
+    [Tooltip("Data asset describing this level.")]
+    public LevelDataSO data;
+
+    /// <summary>
+    /// Reference to the enemy's main base in the scene.
+    /// </summary>
+    [Tooltip("Reference to the enemy's main base in the scene.")]
+    public GameObject enemyMainBase;
+
+    private void Update()
+    {
+        CheckWin();
+    }
+
+    /// <summary>
+    /// Initializes the level using the provided data asset.
+    /// </summary>
+    /// <param name="levelData">Data asset for the level.</param>
+    public void InitializeLevel(LevelDataSO levelData)
+    {
+        data = levelData;
+        if (data == null)
+        {
+            Debug.LogError("[LevelManager] LevelDataSO is null.", this);
+            return;
+        }
+
+        Debug.Log($"[LevelManager] Initializing level: {data.levelName}");
+        SpawnLevelElements();
+    }
+
+    /// <summary>
+    /// Spawns all gameplay elements defined for the level.
+    /// </summary>
+    private void SpawnLevelElements()
+    {
+        // Implementation specific to the game would go here.
+        // For now we simply log for visibility.
+        Debug.Log("[LevelManager] Spawning level elements.");
+    }
+
+    /// <summary>
+    /// Checks if the player has fulfilled win conditions.
+    /// </summary>
+    private void CheckWin()
+    {
+        if (enemyMainBase == null)
+        {
+            Debug.Log("[LevelManager] Enemy base destroyed. Triggering victory.");
+            GameEvents.TriggerOnVictory();
+            enabled = false;
+        }
+    }
+}

--- a/Assets/Scripts/Data/LevelDataSO.cs
+++ b/Assets/Scripts/Data/LevelDataSO.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+/// <summary>
+/// ScriptableObject containing configuration for a single level.
+/// </summary>
+[CreateAssetMenu(fileName = "LevelData", menuName = "TheFist/Level Data")]
+public class LevelDataSO : ScriptableObject
+{
+    [Header("Identification")]
+    [Tooltip("Unique index for the level.")]
+    public int levelIndex;
+
+    [Tooltip("Display name of the level.")]
+    public string levelName = "New Level";
+
+    [Header("Gameplay")]
+    [Tooltip("How often enemies spawn (in seconds or rate units).")]
+    public float enemySpawnRate = 1f;
+}


### PR DESCRIPTION
## Summary
- add `GameState` enum for high-level game flow
- implement `LevelDataSO` scriptable object
- implement `LevelManager` to initialize levels and check victory
- implement `GameManager` singleton to manage states and load levels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870097a644c8323a27f8126df08defc