### PR TITLE
Decouple Interactor from AI movement

### DIFF
--- a/Assets/Scripts/Combat/Attacker.cs
+++ b/Assets/Scripts/Combat/Attacker.cs
@@ -197,6 +197,17 @@ public class Attacker : MonoBehaviour
     }
 
     /// <summary>
+    /// Determines the range of the best attack currently available for the specified target.
+    /// </summary>
+    /// <param name="target">Potential attack target.</param>
+    /// <returns>Range of the chosen attack or 0 if none are in range.</returns>
+    public float GetBestAttackRange(GameObject target)
+    {
+        AttackDefinitionSO attack = SelectBestAttackForTarget(target);
+        return attack != null ? attack.range : 0f;
+    }
+
+    /// <summary>
     /// Handles combat logic executed each frame while engaging a target.
     /// </summary>
     private void HandleCombat()

--- a/Assets/Scripts/Core/Enums/AIMovementState.cs
+++ b/Assets/Scripts/Core/Enums/AIMovementState.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents high level movement states for AI controlled entities.
+/// </summary>
+public enum AIMovementState
+{
+    /// <summary>
+    /// Moving toward a long range strategic target.
+    /// </summary>
+    MovingStrategic,
+
+    /// <summary>
+    /// Focusing on a tactical target announced by an <see cref="Interactor"/>.
+    /// </summary>
+    EngagingTactical
+}


### PR DESCRIPTION
## Summary
- add `AIMovementState` enum for AI movement states
- update `Interactor` to broadcast target acquisition/loss events
- expand `AIStrategyController` to listen for Interactor events and handle tactical movement
- expose `Attacker.GetBestAttackRange` for dynamic tactical distance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874f86b6b948323835b84b44accf925