### PR TITLE
Refactor attack definitions

### DIFF
--- a/Assets/Data/AttackDefinitions/Melee/MeleeDefault1.asset
+++ b/Assets/Data/AttackDefinitions/Melee/MeleeDefault1.asset
@@ -9,14 +9,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 12f10fc6fc2061842830838ad56e51ad, type: 3}
+  m_Script: {fileID: 11500000, guid: 5485eadc9b4f4fb68847c84ef39bb45c, type: 3}
   m_Name: MeleeDefault1
   m_EditorClassIdentifier: 
   attackName: MeleeDefault1
-  attackType: 0
   damage: 10
   range: 2
   cooldown: 1
   animationClipName: MeleeDefault1
-  projectilePrefab: {fileID: 0}
-  projectileSpeed: 10

--- a/Assets/Scripts/Combat/Attacker.cs
+++ b/Assets/Scripts/Combat/Attacker.cs
@@ -262,7 +262,7 @@ public class Attacker : MonoBehaviour
     /// <param name="target">Target to attack.</param>
     private void PerformAttack(AttackDefinitionSO attack, GameObject target)
     {
-        if (attack.attackType == AttackType.Melee)
+        if (attack.AttackType == AttackType.Melee)
         {
             ExecuteMeleeAttack(attack, target);
         }
@@ -304,16 +304,18 @@ public class Attacker : MonoBehaviour
     {
         Debug.Log($"[Attacker] {gameObject.name} performs ranged attack {attack.attackName} on {target.name}");
 
-        if (attack.projectilePrefab != null)
+        RangedAttackDefinitionSO ranged = attack as RangedAttackDefinitionSO;
+
+        if (ranged != null && ranged.projectilePrefab != null)
         {
-            GameObject projectileObj = Instantiate(attack.projectilePrefab, transform.position, Quaternion.identity);
+            GameObject projectileObj = Instantiate(ranged.projectilePrefab, transform.position, Quaternion.identity);
             if (projectileObj.TryGetComponent<SimpleProjectile>(out var projectile))
             {
-                projectile.Initialize(gameObject, target, attack);
+                projectile.Initialize(gameObject, target, ranged);
             }
             else
             {
-                Debug.LogWarning($"[Attacker] Projectile prefab {attack.projectilePrefab.name} lacks SimpleProjectile component.", projectileObj);
+                Debug.LogWarning($"[Attacker] Projectile prefab {ranged.projectilePrefab.name} lacks SimpleProjectile component.", projectileObj);
                 if (target.TryGetComponent<Health>(out var health))
                 {
                     health.TakeDamage(attack.damage, gameObject, attack);

--- a/Assets/Scripts/Combat/SimpleProjectile.cs
+++ b/Assets/Scripts/Combat/SimpleProjectile.cs
@@ -9,7 +9,7 @@ public class SimpleProjectile : MonoBehaviour
 
     private GameObject target;
     private GameObject attacker;
-    private AttackDefinitionSO attackData;
+    private RangedAttackDefinitionSO attackData;
 
     /// <summary>
     /// Initializes the projectile with its attacker, target and attack data.
@@ -17,7 +17,7 @@ public class SimpleProjectile : MonoBehaviour
     /// <param name="attacker">Origin of the projectile.</param>
     /// <param name="target">Target to hit.</param>
     /// <param name="attackData">Attack definition used for damage calculation.</param>
-    public void Initialize(GameObject attacker, GameObject target, AttackDefinitionSO attackData)
+    public void Initialize(GameObject attacker, GameObject target, RangedAttackDefinitionSO attackData)
     {
         if (target == null || attackData == null)
         {

--- a/Assets/Scripts/Data/AttackDefinitionSO.cs
+++ b/Assets/Scripts/Data/AttackDefinitionSO.cs
@@ -3,8 +3,7 @@ using UnityEngine;
 /// <summary>
 /// Defines a single attack used by an entity.
 /// </summary>
-[CreateAssetMenu(fileName = "AttackDefinition", menuName = "TheFist/Attack Definition")]
-public class AttackDefinitionSO : ScriptableObject
+public abstract class AttackDefinitionSO : ScriptableObject
 {
     [Header("General")]
 
@@ -15,10 +14,9 @@ public class AttackDefinitionSO : ScriptableObject
     public string attackName = "New Attack";
 
     /// <summary>
-    /// Classification of the attack behaviour.
+    /// Type of attack represented by this definition.
     /// </summary>
-    [Tooltip("Classification of the attack behaviour.")]
-    public AttackType attackType = AttackType.Melee;
+    public abstract AttackType AttackType { get; }
 
     [Header("Stats")]
 
@@ -49,18 +47,4 @@ public class AttackDefinitionSO : ScriptableObject
     [Tooltip("Name of the animation clip in Resources folder to play directly (without using animator states).")]
     public string animationClipName;
 
-    [Header("Projectiles")]
-
-    /// <summary>
-    /// Prefab spawned when executing a ranged attack. Null for melee attacks.
-    /// </summary>
-    [Tooltip("Prefab spawned when executing a ranged attack. Null for melee attacks.")]
-    public GameObject projectilePrefab;
-
-    /// <summary>
-    /// Movement speed for projectiles spawned by this attack.
-    /// Only used when <see cref="projectilePrefab"/> is assigned.
-    /// </summary>
-    [Tooltip("Movement speed of projectiles spawned by this attack.")]
-    public float projectileSpeed = 10f;
 }

--- a/Assets/Scripts/Data/MeleeAttackDefinitionSO.cs
+++ b/Assets/Scripts/Data/MeleeAttackDefinitionSO.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines a melee attack with no projectile data.
+/// </summary>
+[CreateAssetMenu(fileName = "MeleeAttackDefinition", menuName = "TheFist/Attack Definition/Melee")]
+public class MeleeAttackDefinitionSO : AttackDefinitionSO
+{
+    /// <inheritdoc/>
+    public override AttackType AttackType => AttackType.Melee;
+}

--- a/Assets/Scripts/Data/MeleeAttackDefinitionSO.cs.meta
+++ b/Assets/Scripts/Data/MeleeAttackDefinitionSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5485eadc9b4f4fb68847c84ef39bb45c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -740
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/RangedAttackDefinitionSO.cs
+++ b/Assets/Scripts/Data/RangedAttackDefinitionSO.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines a ranged attack that spawns a projectile.
+/// </summary>
+[CreateAssetMenu(fileName = "RangedAttackDefinition", menuName = "TheFist/Attack Definition/Ranged")]
+public class RangedAttackDefinitionSO : AttackDefinitionSO
+{
+    [Header("Projectiles")]
+    [Tooltip("Prefab spawned when executing a ranged attack.")]
+    public GameObject projectilePrefab;
+
+    [Tooltip("Movement speed of projectiles spawned by this attack.")]
+    public float projectileSpeed = 10f;
+
+    /// <inheritdoc/>
+    public override AttackType AttackType => AttackType.Ranged;
+}

--- a/Assets/Scripts/Data/RangedAttackDefinitionSO.cs.meta
+++ b/Assets/Scripts/Data/RangedAttackDefinitionSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c08f9f5a1f04c2ab8d29fdeef87b153
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -740
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- make `AttackDefinitionSO` abstract and remove projectile data
- add `MeleeAttackDefinitionSO` and `RangedAttackDefinitionSO`
- update `Attacker` to handle ranged attack cast and new property
- update `SimpleProjectile` to accept `RangedAttackDefinitionSO`
- clean MeleeDefault1 asset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dfb1b1f888323814856014c5f4689